### PR TITLE
chore: 使用 postcss-mobile-forever 提升桌面端肯访问性，避免大屏大字

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -4,22 +4,18 @@ module.exports = {
         autoprefixer: {
             overrideBrowserslist: ['Android 4.1', 'iOS 7.1', 'Chrome > 31', 'ff > 31', 'ie >= 8']
         },
-        'postcss-px-to-viewport-8-plugin': {
-            unitToConvert: 'px', // 要转化的单位
+        'postcss-mobile-forever': {
+            rootSelector: '#root', // 项目根元素，用于设置居中
             viewportWidth: 375, // UI设计稿的宽度
+            maxDisplayWidth: 520, // 最大宽度
+            disableLandscape: true, // 禁止生成横屏媒体查询
+            disableDesktop: true, // 禁止生成桌面端媒体查询
             unitPrecision: 5, // 转换后的精度，即小数点位数
             propList: ['*'], // 指定转换的css属性的单位，*代表全部css属性的单位都进行转换
             viewportUnit: 'vw', // 指定需要转换成的视窗单位，默认vw
-            fontViewportUnit: 'vw', // 指定字体需要转换成的视窗单位，默认vw
-            selectorBlackList: [], // 指定不转换为视窗单位的类名，
-            minPixelValue: 1, // 默认值1，小于或等于1px则不进行转换
-            mediaQuery: false, // 是否在媒体查询的css代码中也进行转换，默认false
-            replace: true, // 是否转换后直接更换属性值
-            // exclude: /(\/|\\)(node_modules)(\/|\\)/, // 设置忽略文件，用正则做目录名匹配
+            selectorBlackList: [], // 指定不转换为视窗单位的类名
+            valueBlackList: ['1px solid'], // 指定不转换的值
             exclude: [],
-            landscape: false, // 是否处理横屏情况
-            landscapeUnit: 'vw',
-            landscapeWidth: 568
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "lint-staged": "12.5.0",
         "postcss": "^8.1.0",
         "postcss-html": "^1.5.0",
-        "postcss-px-to-viewport-8-plugin": "1.1.7",
+        "postcss-mobile-forever": "^3.4.2",
         "prettier": "^2.8.1",
         "rollup-plugin-visualizer": "^5.9.0",
         "sass": "^1.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,11 +29,10 @@ specifiers:
   esno: ^0.16.3
   husky: ^8.0.3
   lint-staged: 12.5.0
-  localforage: ^1.10.0
   lodash-es: ^4.17.21
   postcss: ^8.1.0
   postcss-html: ^1.5.0
-  postcss-px-to-viewport-8-plugin: 1.1.7
+  postcss-mobile-forever: ^3.4.2
   prettier: ^2.8.1
   prop-types: ^15.8.1
   qs: ^6.11.0
@@ -61,7 +60,6 @@ dependencies:
   antd-mobile: 5.28.2_biqbaboplfbrettd7655fr4n2y
   antd-mobile-icons: 0.3.0
   axios: 1.3.4
-  localforage: 1.10.0
   lodash-es: 4.17.21
   prop-types: 15.8.1
   qs: 6.11.1
@@ -98,7 +96,7 @@ devDependencies:
   lint-staged: 12.5.0
   postcss: 8.4.21
   postcss-html: 1.5.0
-  postcss-px-to-viewport-8-plugin: 1.1.7
+  postcss-mobile-forever: 3.4.2_postcss@8.4.21
   prettier: 2.8.7
   rollup-plugin-visualizer: 5.9.0
   sass: 1.60.0
@@ -1709,7 +1707,7 @@ packages:
     dev: true
 
   /archive-type/4.0.0:
-    resolution: {integrity: sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=}
+    resolution: {integrity: sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==}
     engines: {node: '>=4'}
     dependencies:
       file-type: 4.4.0
@@ -1958,7 +1956,7 @@ packages:
     dev: true
 
   /cacheable-request/2.1.4:
-    resolution: {integrity: sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=}
+    resolution: {integrity: sha512-vag0O2LKZ/najSoUwDbVlnlCFvhBE/7mGTY2B5FgCBDcRD+oVV1HYTOwM6JZfMg/hIcM6IwnTZ1uQQL5/X3xIQ==}
     dependencies:
       clone-response: 1.0.2
       get-stream: 3.0.0
@@ -2121,7 +2119,7 @@ packages:
     dev: true
 
   /clone-response/1.0.2:
-    resolution: {integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=}
+    resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
     dependencies:
       mimic-response: 1.0.1
     dev: true
@@ -3348,7 +3346,7 @@ packages:
     dev: true
 
   /file-type/4.4.0:
-    resolution: {integrity: sha1-G2AOX8ofvcboDApwxxyNul95BsU=}
+    resolution: {integrity: sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ==}
     engines: {node: '>=4'}
     dev: true
 
@@ -3468,7 +3466,7 @@ packages:
     dev: true
 
   /from2/2.3.0:
-    resolution: {integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=}
+    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
@@ -3967,10 +3965,6 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
-  /immediate/3.0.6:
-    resolution: {integrity: sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=}
-    dev: false
-
   /immutable/4.3.0:
     resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
     dev: true
@@ -4062,7 +4056,7 @@ packages:
     dev: false
 
   /into-stream/3.1.0:
-    resolution: {integrity: sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=}
+    resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
     engines: {node: '>=4'}
     dependencies:
       from2: 2.3.0
@@ -4372,7 +4366,7 @@ packages:
     dev: true
 
   /json-buffer/3.0.0:
-    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
     dev: true
 
   /json-parse-even-better-errors/2.3.1:
@@ -4442,12 +4436,6 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /lie/3.1.1:
-    resolution: {integrity: sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=}
-    dependencies:
-      immediate: 3.0.6
-    dev: false
-
   /lilconfig/2.0.5:
     resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
     engines: {node: '>=10'}
@@ -4509,12 +4497,6 @@ packages:
       pinkie-promise: 2.0.1
       strip-bom: 2.0.0
     dev: true
-
-  /localforage/1.10.0:
-    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
-    dependencies:
-      lie: 3.1.1
-    dev: false
 
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -4615,7 +4597,7 @@ packages:
     dev: true
 
   /lowercase-keys/1.0.0:
-    resolution: {integrity: sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=}
+    resolution: {integrity: sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -5068,7 +5050,7 @@ packages:
     dev: true
 
   /p-is-promise/1.1.0:
-    resolution: {integrity: sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=}
+    resolution: {integrity: sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==}
     engines: {node: '>=4'}
     dev: true
 
@@ -5283,10 +5265,12 @@ packages:
       postcss-safe-parser: 6.0.0_postcss@8.4.21
     dev: true
 
-  /postcss-px-to-viewport-8-plugin/1.1.7:
-    resolution: {integrity: sha512-uZP6LnpfBLK1UB0Z+Yli+wDqraGFbZms8/IQqMQHLf0LpQO9AeYxTKHCEgVKcKwiag7ZnRXNDcRYkhtlDcdzNw==}
+  /postcss-mobile-forever/3.4.2_postcss@8.4.21:
+    resolution: {integrity: sha512-77uJ+G18TM4xjpODK/+LGzWkRmIOnNXJDOIQySuCbY/KIZqxvxD7igEmYNsn0ha/e2LypGQ3vwHeeJxV2Kq7nQ==}
+    peerDependencies:
+      postcss: ^8.0.0
     dependencies:
-      object-assign: 4.1.1
+      postcss: 8.4.21
     dev: true
 
   /postcss-safe-parser/6.0.0_postcss@8.4.21:
@@ -5322,7 +5306,7 @@ packages:
     dev: true
 
   /prepend-http/2.0.0:
-    resolution: {integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=}
+    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
     dev: true
 
@@ -5726,7 +5710,7 @@ packages:
     dev: true
 
   /responselike/1.0.2:
-    resolution: {integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=}
+    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==}
     dependencies:
       lowercase-keys: 1.0.1
     dev: true
@@ -5884,7 +5868,7 @@ packages:
     dev: true
 
   /semver-truncate/1.1.2:
-    resolution: {integrity: sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=}
+    resolution: {integrity: sha512-V1fGg9i4CL3qesB6U0L6XAm4xOJiHmt4QAacazumuasc03BvtFGIMCduv01JWQ69Nv+JST9TqhSCiJoxoY031w==}
     engines: {node: '>=0.10.0'}
     dependencies:
       semver: 5.7.1
@@ -5989,7 +5973,7 @@ packages:
     dev: true
 
   /sort-keys/2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -6067,7 +6051,7 @@ packages:
     dev: false
 
   /strict-uri-encode/1.1.0:
-    resolution: {integrity: sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=}
+    resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -6558,7 +6542,7 @@ packages:
     dev: true
 
   /url-parse-lax/3.0.0:
-    resolution: {integrity: sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=}
+    resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
     engines: {node: '>=4'}
     dependencies:
       prepend-http: 2.0.0

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,9 +6,7 @@
     box-sizing: border-box;
 }
 
-html,
-body,
-#app {
+#root {
     width: 100%;
     height: 100%;
     background-color: $background-color;


### PR DESCRIPTION
你好 wuxingxi，我最近写了个插件 [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)，最近在做推广，这个插件主要让视图保持伸缩的同时限制最大宽度，可以用来解决 postcss-px-to-viewport 做移动端适配导致的大屏大字问题。

如果有这方面优化意向，欢迎合并～

下面这张图是用了插件之后桌面端的样子：

![使用插件后的桌面端界面](https://github.com/wuxingxi888/vite-react-h5-template/assets/26893092/9322108c-6400-48ef-afb3-139fca46c313)
